### PR TITLE
Update product image URLs to external vendor links

### DIFF
--- a/app/data/products.ts
+++ b/app/data/products.ts
@@ -58,8 +58,7 @@ export const allProducts: Product[] = [
     subcategory: "Engine Maintenance",
     carModel: "E12/K13/N17",
     brand: "Ridex Plus",
-    image:
-      "https://cdn.builder.io/api/v1/image/assets%2F9067eeb573a94c11b62f6ab0ba539c7c%2Fc17721f3d91d4e33a6b8eade39abad37?format=webp&width=800",
+    image: "https://en.ridex.eu/product/18743865",
     images: [
       "https://cdn.builder.io/api/v1/image/assets%2F9067eeb573a94c11b62f6ab0ba539c7c%2Fc17721f3d91d4e33a6b8eade39abad37?format=webp&width=800",
       "https://cdn.builder.io/api/v1/image/assets%2F9067eeb573a94c11b62f6ab0ba539c7c%2F73765e7657e44cc2a9529e38089d5bd7?format=webp&width=800",
@@ -85,8 +84,7 @@ export const allProducts: Product[] = [
     subcategory: "Engine Maintenance",
     carModel: "E12/K13/N17",
     brand: "STARK",
-    image:
-      "https://cdn.builder.io/api/v1/image/assets%2F9067eeb573a94c11b62f6ab0ba539c7c%2F9b03d66d995f4af29d9d22f4ea1fb05d?format=webp&width=800",
+    image: "https://www.autodoc.co.uk/stark/7989008",
     images: [
       "https://cdn.builder.io/api/v1/image/assets%2F9067eeb573a94c11b62f6ab0ba539c7c%2F9b03d66d995f4af29d9d22f4ea1fb05d?format=webp&width=800",
       "https://cdn.builder.io/api/v1/image/assets%2F9067eeb573a94c11b62f6ab0ba539c7c%2Fd3ebe831b1f24a4089d2c4bfa5d52bcc?format=webp&width=800",
@@ -116,7 +114,7 @@ export const allProducts: Product[] = [
     carModel: "Teana L33 QR25de",
     brand: "KAVO",
     image:
-      "https://cdn.builder.io/api/v1/image/assets%2F9067eeb573a94c11b62f6ab0ba539c7c%2F2482361750974583acdd1c52e22ea06a?format=webp&width=800",
+      "https://www.autodoc.co.uk/kavo-parts/13863456?search=KAVO%20PARTS%20Air%20filter%20(NA-2650)",
     images: [
       "https://cdn.builder.io/api/v1/image/assets%2F9067eeb573a94c11b62f6ab0ba539c7c%2F2482361750974583acdd1c52e22ea06a?format=webp&width=800",
       "https://cdn.builder.io/api/v1/image/assets%2F9067eeb573a94c11b62f6ab0ba539c7c%2F0d78dabb42ee4fe88b079832a69e83e9?format=webp&width=800",
@@ -143,8 +141,7 @@ export const allProducts: Product[] = [
     subcategory: "Engine Maintenance",
     carModel: "DIG-S",
     brand: "JAPKO",
-    image:
-      "https://images.unsplash.com/photo-1619642751034-765dfdf7c58e?w=400&h=300&fit=crop",
+    image: "https://www.autodoc.co.uk/japko/9178528",
     price: 2300,
     rating: 4.5,
     reviews: 56,
@@ -167,7 +164,7 @@ export const allProducts: Product[] = [
     carModel: "DIG-S",
     brand: "TOPRAN",
     image:
-      "https://images.unsplash.com/photo-1619642751034-765dfdf7c58e?w=400&h=300&fit=crop",
+      "https://www.autodoc.co.uk/topran/10136263?search=TOPRAN%20Air%20filter%20(701%20527)",
     price: 2950,
     rating: 4.6,
     reviews: 89,
@@ -213,7 +210,7 @@ export const allProducts: Product[] = [
     carModel: "Puredrive",
     brand: "RIDEX",
     image:
-      "https://images.unsplash.com/photo-1619642751034-765dfdf7c58e?w=400&h=300&fit=crop",
+      "https://www.autodoc.co.uk/ridex/8000845?search=RIDEX%20Air%20filter%20(8A0074)",
     price: 2200,
     rating: 4.5,
     reviews: 134,

--- a/app/data/products.ts
+++ b/app/data/products.ts
@@ -656,7 +656,7 @@ export const allProducts: Product[] = [
     carModel: "DIG-S",
     brand: "RIDEX",
     image:
-      "https://images.unsplash.com/photo-1487754180451-c456f719a1fc?w=400&h=300&fit=crop",
+      "https://www.autodoc.co.uk/ridex/8098417?search=RIDEX%20V-ribbed%20belt%20(305P0095)",
     price: 3200,
     rating: 4.6,
     reviews: 92,
@@ -701,8 +701,7 @@ export const allProducts: Product[] = [
     subcategory: "Engine",
     carModel: "E124wd",
     brand: "RIDEX",
-    image:
-      "https://images.unsplash.com/photo-1487754180451-c456f719a1fc?w=400&h=300&fit=crop",
+    image: "https://www.autodoc.co.uk/ridex/8099120",
     price: 3200,
     rating: 4.5,
     reviews: 65,
@@ -725,7 +724,7 @@ export const allProducts: Product[] = [
     carModel: "DIG-S",
     brand: "DAYCO",
     image:
-      "https://images.unsplash.com/photo-1487754180451-c456f719a1fc?w=400&h=300&fit=crop",
+      "https://www.autodoc.co.uk/dayco/225157?search=DAYCO%20V-ribbed%20belt%20(3PK800)",
     price: 2200,
     rating: 4.6,
     reviews: 54,
@@ -747,8 +746,7 @@ export const allProducts: Product[] = [
     subcategory: "Engine",
     carModel: "E12/K13/N17",
     brand: "KAMOKA",
-    image:
-      "https://images.unsplash.com/photo-1487754180451-c456f719a1fc?w=400&h=300&fit=crop",
+    image: "https://www.rexbo.co.uk/kamoka/v-ribbed-belt-7017009",
     price: 2950,
     rating: 4.4,
     reviews: 43,
@@ -773,7 +771,7 @@ export const allProducts: Product[] = [
     carModel: "E12/K13/N17",
     brand: "STARK",
     image:
-      "https://images.unsplash.com/photo-1552664688-cf412ec27db2?w=400&h=300&fit=crop",
+      "https://www.autodoc.co.uk/stark/12755536?search=STARK%20Wiper%20Blade%20(SKWIB-0940152)",
     price: 1500,
     rating: 4.3,
     reviews: 67,
@@ -796,7 +794,7 @@ export const allProducts: Product[] = [
     carModel: "E12/K13/N17",
     brand: "BOSCH",
     image:
-      "https://images.unsplash.com/photo-1552664688-cf412ec27db2?w=400&h=300&fit=crop",
+      "https://www.autodoc.co.uk/bosch/9464770?search=BOSCH%20Wiper%20Blade%20(3%20397%20014%20128)",
     price: 5950,
     rating: 4.8,
     reviews: 89,
@@ -1155,7 +1153,7 @@ export const allProducts: Product[] = [
     carModel: "Teana L33 QR25de",
     brand: "GS-P",
     image:
-      "https://images.unsplash.com/photo-1486754735734-325b5831c3ad?w=400&h=300&fit=crop",
+      "https://www.autodoc.co.uk/gsp/9865218?search=GSP%20Control%20Arm-%20/%20Trailing%20Arm%20Bush%20(516473)",
     price: 5000,
     rating: 4.6,
     reviews: 34,
@@ -1178,7 +1176,7 @@ export const allProducts: Product[] = [
     carModel: "Teana L33 QR25de",
     brand: "GS-P",
     image:
-      "https://images.unsplash.com/photo-1486754735734-325b5831c3ad?w=400&h=300&fit=crop",
+      "https://www.autodoc.co.uk/gsp/13922081?search=GSP%20Control%20Arm-%20/%20Trailing%20Arm%20Bush%20(532407)",
     price: 3200,
     rating: 4.5,
     reviews: 28,
@@ -1203,7 +1201,7 @@ export const allProducts: Product[] = [
     carModel: "Teana L33 QR25de",
     brand: "RIDEX",
     image:
-      "https://images.unsplash.com/photo-1486754735734-325b5831c3ad?w=400&h=300&fit=crop",
+      "https://www.autodoc.co.uk/ridex/8000270?search=RIDEX%20Anti%20roll%20bar%20link%20(3229S0117)",
     price: 3800,
     rating: 4.7,
     reviews: 67,

--- a/app/data/products.ts
+++ b/app/data/products.ts
@@ -258,7 +258,7 @@ export const allProducts: Product[] = [
     carModel: "Teana L33 QR25de",
     brand: "KAVO",
     image:
-      "https://cdn.builder.io/api/v1/image/assets%2F9067eeb573a94c11b62f6ab0ba539c7c%2F4f708519aa574b72840ccbf786e00a36?format=webp&width=800",
+      "https://www.autodoc.co.uk/kavo-parts/13863570?search=KAVO%20PARTS%20Pollen%20filter%20(NC-2037)",
     images: [
       "https://cdn.builder.io/api/v1/image/assets%2F9067eeb573a94c11b62f6ab0ba539c7c%2F4f708519aa574b72840ccbf786e00a36?format=webp&width=800",
       "https://cdn.builder.io/api/v1/image/assets%2F9067eeb573a94c11b62f6ab0ba539c7c%2Ffa041b36e7354dbfa57df34b49735105?format=webp&width=800",
@@ -285,7 +285,7 @@ export const allProducts: Product[] = [
     carModel: "Teana L33 QR25de",
     brand: "KAVO",
     image:
-      "https://images.unsplash.com/photo-1619642751034-765dfdf7c58e?w=400&h=300&fit=crop",
+      "https://www.autodoc.co.uk/kavo-parts/13863571?search=KAVO%20PARTS%20Pollen%20filter%20(NC-2037C)",
     price: 6500,
     rating: 4.8,
     reviews: 23,
@@ -307,8 +307,7 @@ export const allProducts: Product[] = [
     subcategory: "HVAC",
     carModel: "E12/K13/N17",
     brand: "RIDEX",
-    image:
-      "https://images.unsplash.com/photo-1619642751034-765dfdf7c58e?w=400&h=300&fit=crop",
+    image: "https://www.autodoc.co.uk/ridex/8059207",
     price: 1200,
     rating: 4.4,
     reviews: 156,
@@ -330,8 +329,7 @@ export const allProducts: Product[] = [
     subcategory: "HVAC",
     carModel: "E12/K13/N17",
     brand: "JPN",
-    image:
-      "https://images.unsplash.com/photo-1619642751034-765dfdf7c58e?w=400&h=300&fit=crop",
+    image: "https://www.trodo.com/filter-cabin-air-jpn-40f1025-jpn",
     price: 2200,
     rating: 4.3,
     reviews: 67,
@@ -377,7 +375,7 @@ export const allProducts: Product[] = [
     carModel: "E12/K13/N17",
     brand: "Denkermann",
     image:
-      "https://images.unsplash.com/photo-1619642751034-765dfdf7c58e?w=400&h=300&fit=crop",
+      "https://www.autodoc.co.uk/denckermann/17234692?search=DENCKERMANN%20Pollen%20filter%20(M110850K)",
     price: 3000,
     rating: 4.6,
     reviews: 45,
@@ -400,7 +398,7 @@ export const allProducts: Product[] = [
     carModel: "E12/K13/N17",
     brand: "Denkermann",
     image:
-      "https://images.unsplash.com/photo-1619642751034-765dfdf7c58e?w=400&h=300&fit=crop",
+      "https://www.autodoc.co.uk/denckermann/17234691?search=DENCKERMANN%20Pollen%20filter%20(M110850A)",
     price: 4200,
     rating: 4.8,
     reviews: 29,
@@ -422,8 +420,7 @@ export const allProducts: Product[] = [
     subcategory: "HVAC",
     carModel: "E12/K13/N17",
     brand: "RIDEX",
-    image:
-      "https://images.unsplash.com/photo-1619642751034-765dfdf7c58e?w=400&h=300&fit=crop",
+    image: "https://www.autodoc.co.uk/ridex/16418296",
     price: 1500,
     rating: 4.4,
     reviews: 78,

--- a/app/data/products.ts
+++ b/app/data/products.ts
@@ -1037,7 +1037,7 @@ export const allProducts: Product[] = [
     carModel: "H4 models",
     brand: "OSRAM",
     image:
-      "https://images.unsplash.com/photo-1552664688-cf412ec27db2?w=400&h=300&fit=crop",
+      "https://www.osram.com/ecat/NIGHT%20BREAKER%20200-Halogen%20headlight%20lamps-Car%20lighting-Automotive/com/en/GPS01_3495633/ZMP_4062357/",
     price: 7500,
     rating: 4.8,
     reviews: 145,
@@ -1063,7 +1063,7 @@ export const allProducts: Product[] = [
     carModel: "H4 models",
     brand: "OSRAM",
     image:
-      "https://images.unsplash.com/photo-1552664688-cf412ec27db2?w=400&h=300&fit=crop",
+      "https://www.osram.com/ecat/COOL%20BLUE%20INTENSE%20(NEXT%20GEN)-Halogen%20headlight%20lamps-Car%20lighting-Automotive/com/en/GPS01_3570150/",
     price: 5500,
     rating: 4.6,
     reviews: 89,
@@ -1089,7 +1089,7 @@ export const allProducts: Product[] = [
     carModel: "H4 models",
     brand: "OSRAM",
     image:
-      "https://images.unsplash.com/photo-1552664688-cf412ec27db2?w=400&h=300&fit=crop",
+      "https://www.osram.com/ecat/NIGHT%20BREAKER%20220-Halogen%20headlight%20lamps-Car%20lighting-Automotive/com/en/GPS01_4099561/",
     price: 8500,
     rating: 4.9,
     reviews: 67,
@@ -1117,7 +1117,7 @@ export const allProducts: Product[] = [
     carModel: "H4 models",
     brand: "OSRAM",
     image:
-      "https://images.unsplash.com/photo-1552664688-cf412ec27db2?w=400&h=300&fit=crop",
+      "https://dammedia.osram.info/media/resource/900/osram-dam-20577281/COOL%20BLUE%20INTENSE%20W5W%202825CBN-02B.jpg",
     price: 2500,
     rating: 4.4,
     reviews: 123,
@@ -1217,8 +1217,7 @@ export const allProducts: Product[] = [
     subcategory: "Interior",
     carModel: "All",
     brand: "RIDEX",
-    image:
-      "https://images.unsplash.com/photo-1544829099-b9a0c5303bea?w=400&h=300&fit=crop",
+    image: "https://en.ridex.eu/product/17152690",
     price: 850,
     rating: 4.3,
     reviews: 234,
@@ -1244,8 +1243,7 @@ export const allProducts: Product[] = [
     subcategory: "Interior",
     carModel: "All",
     brand: "RIDEX",
-    image:
-      "https://images.unsplash.com/photo-1544829099-b9a0c5303bea?w=400&h=300&fit=crop",
+    image: "https://en.ridex.eu/product/17371417",
     price: 850,
     rating: 4.2,
     reviews: 156,

--- a/app/data/products.ts
+++ b/app/data/products.ts
@@ -818,8 +818,7 @@ export const allProducts: Product[] = [
     subcategory: "Engine",
     carModel: "Note E12 DIG-S",
     brand: "NGK",
-    image:
-      "https://images.unsplash.com/photo-1580273916550-e323be2ae537?w=400&h=300&fit=crop",
+    image: "https://www.sparkplugs.co.uk/ngk-spark-plug-dilkar7e11hs-97439",
     price: 4600,
     rating: 4.9,
     reviews: 203,
@@ -842,8 +841,7 @@ export const allProducts: Product[] = [
     subcategory: "Engine",
     carModel: "Note E12 Puredrive/March K13/Latio N17/X-Trail T30/Dualis J10",
     brand: "NGK",
-    image:
-      "https://images.unsplash.com/photo-1580273916550-e323be2ae537?w=400&h=300&fit=crop",
+    image: "https://www.sparkplugs.co.uk/ngk-spark-plug-dilkar6a11-9029-5",
     price: 4250,
     rating: 4.8,
     reviews: 156,
@@ -871,8 +869,7 @@ export const allProducts: Product[] = [
     subcategory: "Engine",
     carModel: "Note E11 1.5L/Tiida C11/SC11/AD/Wingroad/Teana L33",
     brand: "NGK",
-    image:
-      "https://images.unsplash.com/photo-1580273916550-e323be2ae537?w=400&h=300&fit=crop",
+    image: "https://www.sparkplugs.co.uk/ngk-spark-plug-dilzkar6a11-91691-5",
     price: 3450,
     rating: 4.7,
     reviews: 134,
@@ -902,8 +899,7 @@ export const allProducts: Product[] = [
     subcategory: "Engine",
     carModel: "E-power",
     brand: "NGK",
-    image:
-      "https://images.unsplash.com/photo-1580273916550-e323be2ae537?w=400&h=300&fit=crop",
+    image: "https://www.sparkplugs.co.uk/ngk-spark-plug-lzkar6ap-11-6643-5",
     price: 4250,
     rating: 4.8,
     reviews: 67,
@@ -925,8 +921,7 @@ export const allProducts: Product[] = [
     subcategory: "Engine",
     carModel: "Mazda Skyactive",
     brand: "NGK",
-    image:
-      "https://images.unsplash.com/photo-1580273916550-e323be2ae537?w=400&h=300&fit=crop",
+    image: "https://www.sparkplugs.co.uk/ngk-spark-plug-ilkar7l11-94124-5",
     price: 4650,
     rating: 4.7,
     reviews: 89,
@@ -947,8 +942,7 @@ export const allProducts: Product[] = [
     subcategory: "Engine",
     carModel: "Mercedes Benz",
     brand: "NGK",
-    image:
-      "https://images.unsplash.com/photo-1580273916550-e323be2ae537?w=400&h=300&fit=crop",
+    image: "https://www.sparkplugs.co.uk/ngk-spark-plug-silzkfr8e7s-90654-5",
     price: 2750,
     rating: 4.6,
     reviews: 45,
@@ -969,8 +963,7 @@ export const allProducts: Product[] = [
     subcategory: "Engine",
     carModel: "Xtrail T30/B15/WingRoad Y11",
     brand: "NGK",
-    image:
-      "https://images.unsplash.com/photo-1580273916550-e323be2ae537?w=400&h=300&fit=crop",
+    image: "https://www.sparkplugs.co.uk/ngk-spark-plug-lfr5a-11-6376-5",
     price: 1850,
     rating: 4.4,
     reviews: 78,
@@ -994,8 +987,7 @@ export const allProducts: Product[] = [
     subcategory: "Engine",
     carModel: "X-trail T32",
     brand: "NGK",
-    image:
-      "https://images.unsplash.com/photo-1580273916550-e323be2ae537?w=400&h=300&fit=crop",
+    image: "https://www.sparkplugs.co.uk/ngk-spark-plug-90565-5",
     price: 4500,
     rating: 4.8,
     reviews: 56,

--- a/app/data/products.ts
+++ b/app/data/products.ts
@@ -468,7 +468,7 @@ export const allProducts: Product[] = [
     carModel: "E12/K13/N17/L33",
     brand: "TOPRAN",
     image:
-      "https://images.unsplash.com/photo-1487754180451-c456f719a1fc?w=400&h=300&fit=crop",
+      "https://www.trodo.com/hydraulic-filter-automatic-transmission-topran-702-466",
     price: 2250,
     rating: 4.5,
     reviews: 67,
@@ -516,7 +516,7 @@ export const allProducts: Product[] = [
     carModel: "E12/K13/N17",
     brand: "LPR",
     image:
-      "https://images.unsplash.com/photo-1621839673705-6617adf9e890?w=400&h=300&fit=crop",
+      "https://www.autodoc.co.uk/lpr/15833801?search=LPR%20Brake%20pad%20set%20(05P1686)",
     price: 7500,
     rating: 4.7,
     reviews: 89,
@@ -538,8 +538,7 @@ export const allProducts: Product[] = [
     subcategory: "Brakes",
     carModel: "E12/K13/N18",
     brand: "JAPKO",
-    image:
-      "https://images.unsplash.com/photo-1621839673705-6617adf9e890?w=400&h=300&fit=crop",
+    image: "https://www.autodoc.co.uk/japko/13039679",
     price: 7500,
     rating: 4.6,
     reviews: 78,
@@ -562,7 +561,7 @@ export const allProducts: Product[] = [
     carModel: "E12/K13/N19",
     brand: "KAVO",
     image:
-      "https://images.unsplash.com/photo-1621839673705-6617adf9e890?w=400&h=300&fit=crop",
+      "https://www.autodoc.co.uk/kavo-parts/11556378?search=KAVO%20PARTS%20Brake%20pad%20set%20(KBP-6613)",
     price: 7500,
     rating: 4.8,
     reviews: 56,
@@ -584,8 +583,7 @@ export const allProducts: Product[] = [
     subcategory: "Brakes",
     carModel: "E12/K13/N17",
     brand: "RIDEX",
-    image:
-      "https://images.unsplash.com/photo-1621839673705-6617adf9e890?w=400&h=300&fit=crop",
+    image: "https://en.ridex.eu/product/7999897",
     price: 4000,
     rating: 4.5,
     reviews: 134,
@@ -608,8 +606,7 @@ export const allProducts: Product[] = [
     subcategory: "Brakes",
     carModel: "E12/K13/N17",
     brand: "RIDEX PLUS",
-    image:
-      "https://images.unsplash.com/photo-1621839673705-6617adf9e890?w=400&h=300&fit=crop",
+    image: "https://en.ridex.eu/product/7999897",
     price: 6200,
     rating: 4.7,
     reviews: 89,
@@ -634,7 +631,7 @@ export const allProducts: Product[] = [
     carModel: "E12/K13/N17",
     brand: "Brembo",
     image:
-      "https://images.unsplash.com/photo-1621839673705-6617adf9e890?w=400&h=300&fit=crop",
+      "https://www.autodoc.co.uk/brembo/1662328?search=BREMBO%20Brake%20Shoe%20Set%20(S%2056%20510)",
     price: 5950,
     rating: 4.8,
     reviews: 67,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -659,11 +659,11 @@ export default function HomePage() {
           </div>
           <div className="hidden md:block">
             <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
-              {(newArrivals.length > 0 ? newArrivals : allProducts).map(
-                (product) => (
+              {(newArrivals.length > 0 ? newArrivals : allProducts)
+                .slice(0, 4)
+                .map((product) => (
                   <ProductCard key={product.id} product={product} />
-                ),
-              )}
+                ))}
             </div>
           </div>
         </div>

--- a/scripts/product-image-mappings.json
+++ b/scripts/product-image-mappings.json
@@ -1,0 +1,260 @@
+{
+  "7O0026P": {
+    "image": "https://en.ridex.eu/product/18743865",
+    "stockLevel": 30,
+    "inStock": true,
+    "price": 1800
+  },
+  "SKOF-0860025": {
+    "image": "https://www.autodoc.co.uk/stark/7989008",
+    "stockLevel": 7,
+    "inStock": true,
+    "price": 1800
+  },
+  "NA-2650": {
+    "image": "https://www.autodoc.co.uk/kavo-parts/13863456?search=KAVO%20PARTS%20Air%20filter%20(NA-2650)",
+    "stockLevel": 0,
+    "inStock": false,
+    "price": 4500
+  },
+  "NC-2037": {
+    "image": "https://www.autodoc.co.uk/kavo-parts/13863570?search=KAVO%20PARTS%20Pollen%20filter%20(NC-2037)",
+    "stockLevel": 1,
+    "inStock": true,
+    "price": 4000
+  },
+  "NC-2037C": {
+    "image": "https://www.autodoc.co.uk/kavo-parts/13863571?search=KAVO%20PARTS%20Pollen%20filter%20(NC-2037C)",
+    "stockLevel": 0,
+    "inStock": false,
+    "price": 6500
+  },
+  "424I0259": {
+    "image": "https://www.autodoc.co.uk/ridex/8059207",
+    "stockLevel": 50,
+    "inStock": true,
+    "price": 1200
+  },
+  "516473": {
+    "image": "https://www.autodoc.co.uk/gsp/9865218?search=GSP%20Control%20Arm-%20/%20Trailing%20Arm%20Bush%20(516473)",
+    "stockLevel": 2,
+    "inStock": true,
+    "price": 5000
+  },
+  "532407": {
+    "image": "https://www.autodoc.co.uk/gsp/13922081?search=GSP%20Control%20Arm-%20/%20Trailing%20Arm%20Bush%20(532407)",
+    "stockLevel": 2,
+    "inStock": true,
+    "price": 3200
+  },
+  "3229S0117": {
+    "image": "https://www.autodoc.co.uk/ridex/8000270?search=RIDEX%20Anti%20roll%20bar%20link%20(3229S0117)",
+    "stockLevel": 4,
+    "inStock": true,
+    "price": 3800
+  },
+  "NB200H4": {
+    "image": "https://www.osram.com/ecat/NIGHT%20BREAKER%20200-Halogen%20headlight%20lamps-Car%20lighting-Automotive/com/en/GPS01_3495633/ZMP_4062357/",
+    "stockLevel": 0,
+    "inStock": false,
+    "price": 7500
+  },
+  "CBI100H4": {
+    "image": "https://www.osram.com/ecat/COOL%20BLUE%20INTENSE%20(NEXT%20GEN)-Halogen%20headlight%20lamps-Car%20lighting-Automotive/com/en/GPS01_3570150/",
+    "stockLevel": 14,
+    "inStock": true,
+    "price": 5500
+  },
+  "NB220H4": {
+    "image": "https://www.osram.com/ecat/NIGHT%20BREAKER%20220-Halogen%20headlight%20lamps-Car%20lighting-Automotive/com/en/GPS01_4099561/",
+    "stockLevel": 5,
+    "inStock": true,
+    "price": 8500
+  },
+  "W5W-CBI": {
+    "image": "https://dammedia.osram.info/media/resource/900/osram-dam-20577281/COOL%20BLUE%20INTENSE%20W5W%202825CBN-02B.jpg",
+    "stockLevel": 6,
+    "inStock": true,
+    "price": 2500
+  },
+  "20148": {
+    "image": "https://www.autodoc.co.uk/japko/9178528",
+    "stockLevel": 1,
+    "inStock": true,
+    "price": 2300
+  },
+  "701527": {
+    "image": "https://www.autodoc.co.uk/topran/10136263?search=TOPRAN%20Air%20filter%20(701%20527)",
+    "stockLevel": 7,
+    "inStock": true,
+    "price": 2950
+  },
+  "8A0074": {
+    "image": "https://www.autodoc.co.uk/ridex/8000845?search=RIDEX%20Air%20filter%20(8A0074)",
+    "stockLevel": 60,
+    "inStock": true,
+    "price": 2200
+  },
+  "40F1025-JPN": {
+    "image": "https://www.trodo.com/filter-cabin-air-jpn-40f1025-jpn",
+    "stockLevel": 0,
+    "inStock": false,
+    "price": 2200
+  },
+  "M110850K": {
+    "image": "https://www.autodoc.co.uk/denckermann/17234692?search=DENCKERMANN%20Pollen%20filter%20(M110850K)",
+    "stockLevel": 0,
+    "inStock": false,
+    "price": 3000
+  },
+  "M110850A": {
+    "image": "https://www.autodoc.co.uk/denckermann/17234691?search=DENCKERMANN%20Pollen%20filter%20(M110850A)",
+    "stockLevel": 0,
+    "inStock": false,
+    "price": 4200
+  },
+  "424I0678": {
+    "image": "https://www.autodoc.co.uk/ridex/16418296",
+    "stockLevel": 2,
+    "inStock": true,
+    "price": 1500
+  },
+  "702466": {
+    "image": "https://www.trodo.com/hydraulic-filter-automatic-transmission-topran-702-466",
+    "stockLevel": 0,
+    "inStock": false,
+    "price": 2250
+  },
+  "LPR05P1686": {
+    "image": "https://www.autodoc.co.uk/lpr/15833801?search=LPR%20Brake%20pad%20set%20(05P1686)",
+    "stockLevel": 0,
+    "inStock": false,
+    "price": 7500
+  },
+  "501002": {
+    "image": "https://www.autodoc.co.uk/japko/13039679",
+    "stockLevel": 0,
+    "inStock": false,
+    "price": 7500
+  },
+  "KBP-6613": {
+    "image": "https://www.autodoc.co.uk/kavo-parts/11556378?search=KAVO%20PARTS%20Brake%20pad%20set%20(KBP-6613)",
+    "stockLevel": 0,
+    "inStock": false,
+    "price": 7500
+  },
+  "402B0234": {
+    "image": "https://en.ridex.eu/product/7999897",
+    "stockLevel": 15,
+    "inStock": true,
+    "price": 4000
+  },
+  "402B0234P": {
+    "image": "https://en.ridex.eu/product/7999897",
+    "stockLevel": 10,
+    "inStock": true,
+    "price": 6200
+  },
+  "S56510": {
+    "image": "https://www.autodoc.co.uk/brembo/1662328?search=BREMBO%20Brake%20Shoe%20Set%20(S%2056%20510)",
+    "stockLevel": 2,
+    "inStock": true,
+    "price": 5950
+  },
+  "305P0095": {
+    "image": "https://www.autodoc.co.uk/ridex/8098417?search=RIDEX%20V-ribbed%20belt%20(305P0095)",
+    "stockLevel": 58,
+    "inStock": true,
+    "price": 3200
+  },
+  "305P0310": {
+    "image": "https://www.autodoc.co.uk/ridex/8099120",
+    "stockLevel": 27,
+    "inStock": true,
+    "price": 3200
+  },
+  "3PK800": {
+    "image": "https://www.autodoc.co.uk/dayco/225157?search=DAYCO%20V-ribbed%20belt%20(3PK800)",
+    "stockLevel": 20,
+    "inStock": true,
+    "price": 2200
+  },
+  "KA07017009": {
+    "image": "https://www.rexbo.co.uk/kamoka/v-ribbed-belt-7017009",
+    "stockLevel": 19,
+    "inStock": true,
+    "price": 2950
+  },
+  "SKWIB-0940152": {
+    "image": "https://www.autodoc.co.uk/stark/12755536?search=STARK%20Wiper%20Blade%20(SKWIB-0940152)",
+    "stockLevel": 4,
+    "inStock": true,
+    "price": 1500
+  },
+  "3397014128": {
+    "image": "https://www.autodoc.co.uk/bosch/9464770?search=BOSCH%20Wiper%20Blade%20(3%20397%20014%20128)",
+    "stockLevel": 0,
+    "inStock": false,
+    "price": 5950
+  },
+  "DILKAR7E11HS(97439)": {
+    "image": "https://www.sparkplugs.co.uk/ngk-spark-plug-dilkar7e11hs-97439",
+    "stockLevel": 65,
+    "inStock": true,
+    "price": 4600
+  },
+  "DILKAR6A11(9029)": {
+    "image": "https://www.sparkplugs.co.uk/ngk-spark-plug-dilkar6a11-9029-5",
+    "stockLevel": 12,
+    "inStock": true,
+    "price": 4250
+  },
+  "DILZKAR6A11(91691)": {
+    "image": "https://www.sparkplugs.co.uk/ngk-spark-plug-dilzkar6a11-91691-5",
+    "stockLevel": 22,
+    "inStock": true,
+    "price": 3450
+  },
+  "LZKAR6AP-11(6643)": {
+    "image": "https://www.sparkplugs.co.uk/ngk-spark-plug-lzkar6ap-11-6643-5",
+    "stockLevel": 0,
+    "inStock": false,
+    "price": 4250
+  },
+  "ILKAR7L11(94124)": {
+    "image": "https://www.sparkplugs.co.uk/ngk-spark-plug-ilkar7l11-94124-5",
+    "stockLevel": 24,
+    "inStock": true,
+    "price": 4650
+  },
+  "SILZKFR8E7S(90654)": {
+    "image": "https://www.sparkplugs.co.uk/ngk-spark-plug-silzkfr8e7s-90654-5",
+    "stockLevel": 16,
+    "inStock": true,
+    "price": 2750
+  },
+  "LFR5A-11(6376)": {
+    "image": "https://www.sparkplugs.co.uk/ngk-spark-plug-lfr5a-11-6376-5",
+    "stockLevel": 16,
+    "inStock": true,
+    "price": 1850
+  },
+  "DILKAR7D11H(90565)": {
+    "image": "https://www.sparkplugs.co.uk/ngk-spark-plug-90565-5",
+    "stockLevel": 24,
+    "inStock": true,
+    "price": 4500
+  },
+  "100207A0002": {
+    "image": "https://en.ridex.eu/product/17152690",
+    "stockLevel": 29,
+    "inStock": true,
+    "price": 850
+  },
+  "100202A0003": {
+    "image": "https://en.ridex.eu/product/17371417",
+    "stockLevel": 30,
+    "inStock": true,
+    "price": 850
+  }
+}

--- a/scripts/update-product-images.js
+++ b/scripts/update-product-images.js
@@ -1,0 +1,167 @@
+const fs = require("fs");
+const path = require("path");
+
+// Raw product data from user input
+const rawProductData = `
+RIDEX Oil Filter	Oil Filter	E12/K13/N17	7O0026 	RIDEX	68	1,300	 upto 10k kms	7O0026 RIDEX Oil Filter with one anti-return valve, Spin-on Filter ▷ AUTODOC price and review
+RIDEX Plus Oil Filter	Oil Filter	E12/K13/N17	7O0026P	Ridex Plus	30	1,800	Upto 15k kms	https://en.ridex.eu/product/18743865
+STARK  Oil Filter	Oil Filter	E12/K13/N17	SKOF-0860025	STARK 	7	1,800	Upto 15k kms	https://www.autodoc.co.uk/stark/7989008
+KAVO Air Filter	Air Filter	Teana L33 QR25de	 NA-2650 	KAVO	0	4,500	Aftermarket OE Qualityup-to 15k kms	https://www.autodoc.co.uk/kavo-parts/13863456?search=KAVO%20PARTS%20Air%20filter%20(NA-2650)
+KAVO Cabin Filter	Cabin Filter	Teana L33 QR25de	NC-2037	KAVO	1	4,000	Aftermarket OE Quality - up-to 15k kms	https://www.autodoc.co.uk/kavo-parts/13863570?search=KAVO%20PARTS%20Pollen%20filter%20(NC-2037)
+KAVO Cabin Filter	Cabin Filter	Teana L33 QR25de	NC-2037C	KAVO	0	6,500	Aftermarket OE Quality - up-to 30k kms	https://www.autodoc.co.uk/kavo-parts/13863571?search=KAVO%20PARTS%20Pollen%20filter%20(NC-2037C)
+RIDEX HEPA Cabin Filter	Cabin Filter	E12/K13/N17	424I0259	RIDEX	50	1,200		https://www.autodoc.co.uk/ridex/8059207
+GS-P Arm Bushing - Large	Arm Bushing - Large	Teana L33 QR25de	516473	GS-P	2	5,000		https://www.autodoc.co.uk/gsp/9865218?search=GSP%20Control%20Arm-%20/%20Trailing%20Arm%20Bush%20(516473)
+GS-P Arm Bushing - Small	Arm Bushing - Small	Teana L33 QR25de	532407	GS-P	2	3,200		https://www.autodoc.co.uk/gsp/13922081?search=GSP%20Control%20Arm-%20/%20Trailing%20Arm%20Bush%20(532407)
+RIDEX  Stabilizer links	Stabilizer links	Teana L33 QR25de	3229S0117	RIDEX 	4	3,800		https://www.autodoc.co.uk/ridex/8000270?search=RIDEX%20Anti%20roll%20bar%20link%20(3229S0117)
+OSRAM Headlight bulbs	Headlight bulbs	H4 models	NB200H4 	OSRAM	0	7,500	(pack of 2)	https://www.osram.com/ecat/NIGHT%20BREAKER%20200-Halogen%20headlight%20lamps-Car%20lighting-Automotive/com/en/GPS01_3495633/ZMP_4062357/
+OSRAM Headlight bulbs	Headlight bulbs	H4 models	CBI100H4	OSRAM	14	5,500	 (pack of 2)	https://www.osram.com/ecat/COOL%20BLUE%20INTENSE%20(NEXT%20GEN)-Halogen%20headlight%20lamps-Car%20lighting-Automotive/com/en/GPS01_3570150/
+OSRAM Headlight bulbs	Headlight bulbs	H4 models	NB220H4	OSRAM	5	8,500	(pack of 2)	https://www.osram.com/ecat/NIGHT%20BREAKER%20220-Halogen%20headlight%20lamps-Car%20lighting-Automotive/com/en/GPS01_4099561/
+OSRAM Parking lights	Parking lights	H4 models	W5W - CBI 	OSRAM	6	2,500	(pack of 2)	https://dammedia.osram.info/media/resource/900/osram-dam-20577281/COOL%20BLUE%20INTENSE%20W5W%202825CBN-02B.jpg
+JAPKO Air filter	Air filter	DIG-S	20148	JAPKO	1	2,300	Aftermarket OE Quality - upto 10k kms	https://www.autodoc.co.uk/japko/9178528
+TOPRAN Air filter	Air filter	DIG-S	701527	TOPRAN	7	2,950	Aftermarket OE Quality - upto 15k kms	https://www.autodoc.co.uk/topran/10136263?search=TOPRAN%20Air%20filter%20(701%20527)
+JPN Air filter	Air filter	DIG-S		JPN	9	2,300		
+RIDEX Air filter	Air filter	Puredrive	8A0074	RIDEX	60	2,200	Aftermarket OE Quality - upto 15k kms	https://www.autodoc.co.uk/ridex/8000845?search=RIDEX%20Air%20filter%20(8A0074)
+RIDEX Air filter	Air filter	T32	8A0461	RIDEX	1	2,650		
+JPN Cabin Filter	Cabin Filter	E12/K13/N17	40F1025-JPN	JPN	0	2,200	Normal	https://www.trodo.com/filter-cabin-air-jpn-40f1025-jpn
+Kamoka Cabin Filter	Cabin Filter	E12/K13/N18	F518801	KAMOKA 	3	2,200	Normal	
+Denkermann  Cabin Filter	Cabin Filter	E12/K13/N17	M110850K 	Denkermann 	0	3,000	 Activated Carbon/Charcoal	https://www.autodoc.co.uk/denckermann/17234692?search=DENCKERMANN%20Pollen%20filter%20(M110850K)
+Denkermann Cabin Filter	Cabin Filter	E12/K13/N17	M110850A 	Denkermann	0	4,200	Antibacterial, Pollen Filter, Anti-Allergen P.M.2.5	https://www.autodoc.co.uk/denckermann/17234691?search=DENCKERMANN%20Pollen%20filter%20(M110850A)
+RIDEX ActivCab Cabin Filter	Cabin Filter	E12/K13/N17	424I0678	RIDEX	2	1,500		https://www.autodoc.co.uk/ridex/16418296
+RIDEX HEPA Cabin Filter	Cabin Filter	T32	424I0390	RIDEX	1	1,550		
+TOPRAN CVT Filter	CVT Filter	E12/K13/N17/L33, etc	702466	TOPRAN	0	2,250	Aftermarket OE Quality	https://www.trodo.com/hydraulic-filter-automatic-transmission-topran-702-466
+BLUEPRINT CVT Filter	CVT Filter	E12/K13/N17/L33, etc	ADN12141	BLUEPRINT	1	2,250		
+LPR Brake Pads	Brake Pads	E12/K13/N17	LPR 05P1686	LPR	0	7,500	Aftermarket OE Quality - 15k - 30k kms	https://www.autodoc.co.uk/lpr/15833801?search=LPR%20Brake%20pad%20set%20(05P1686)
+JAPKO Brake Pads	Brake Pads	E12/K13/N18	501002	JAPKO	0	7,500	Aftermarket OE Quality - 15k - 30k kms	https://www.autodoc.co.uk/japko/13039679
+KAVO Brake Pads	Brake Pads	E12/K13/N19	KBP-6613	KAVO	0	7,500	Aftermarket OE Quality - 15k - 30k kms	https://www.autodoc.co.uk/kavo-parts/11556378?search=KAVO%20PARTS%20Brake%20pad%20set%20(KBP-6613)
+RIDEX Brake Pads	Brake Pads	E12/K13/N17	402B0234	RIDEX	15	4,000		https://en.ridex.eu/product/7999897
+RIDEX PLUS Brake Pads	Brake Pads	E12/K13/N17	402B0234P	RIDEX PLUS	10	6,200		https://en.ridex.eu/product/7999897
+Brembo Brake Shoes - Rear	Brake Shoes - Rear	E12/K13/N17	S 56 510	Brembo	2	5,950		https://www.autodoc.co.uk/brembo/1662328?search=BREMBO%20Brake%20Shoe%20Set%20(S%2056%20510)
+RIDEX  V-belt - Alternator 6PK2080	V-belt - Alternator 6PK2080	DIG-S	305P0095	RIDEX 	58	3,200		https://www.autodoc.co.uk/ridex/8098417?search=RIDEX%20V-ribbed%20belt%20(305P0095)
+BOSCH V-belt - Alternator 6PK2081	V-belt - Alternator 6PK2081	DIG-S		BOSCH	8	3,200		
+RIDEX V-belt - Alternator	V-Belt Alternator 7PK1988	E124wd	305P0310	RIDEX	27	3,200		https://www.autodoc.co.uk/ridex/8099120
+DAYCO V-belt - Supercharger 3PK800	V-belt - Supercharger 3PK800	DIG-S	3PK800	DAYCO	20	2,200		https://www.autodoc.co.uk/dayco/225157?search=DAYCO%20V-ribbed%20belt%20(3PK800)
+KAMOKA  V-belt - Alternator 7PK1165	V-belt - Alternator 7PK1165	E12/K13/N17	KA07017009	KAMOKA 	19	2,950		https://www.rexbo.co.uk/kamoka/v-ribbed-belt-7017009
+STARK  Rear Wiper	Rear Wiper	E12/K13/N17	SKWIB-0940152	STARK 	4	1,500		https://www.autodoc.co.uk/stark/12755536?search=STARK%20Wiper%20Blade%20(SKWIB-0940152)
+BOSCH Front Wiper Set	Front Wiper Set	E12/K13/N17	3397014128	BOSCH	0	5,950	(Pack of 2)	https://www.autodoc.co.uk/bosch/9464770?search=BOSCH%20Wiper%20Blade%20(3%20397%20014%20128)
+NGK Spark plugs	Spark plugs	Note E12 DIG-S	 DILKAR7E11HS (97439) 	NGK	65	4600		https://www.sparkplugs.co.uk/ngk-spark-plug-dilkar7e11hs-97439
+NGK Spark plugs	Spark plugs	Note E12 Puredrive, March K13, Latio N17, X-Trail T30, Dualis J10	DILKAR6A11 (9029)	NGK	12	4250		https://www.sparkplugs.co.uk/ngk-spark-plug-dilkar6a11-9029-5
+NGK Spark plugs	Spark plugs	Note E11 1.5L, Tiida C11/SC11, AD/Wingroad, Teana L33 	DILZKAR6A11 (91691)	NGK	22	3450		https://www.sparkplugs.co.uk/ngk-spark-plug-dilzkar6a11-91691-5
+NGK Spark plugs	Spark plugs	E-power	LZKAR6AP-11 (6643)	NGK	0	4250		https://www.sparkplugs.co.uk/ngk-spark-plug-lzkar6ap-11-6643-5
+NGK Spark plugs	Spark plugs	Mazda Skyactive	ILKAR7L11 (94124)	NGK	24	4650		https://www.sparkplugs.co.uk/ngk-spark-plug-ilkar7l11-94124-5
+NGK Spark plugs	Spark plugs	Mercedes Benz	SILZKFR8E7S (90654)	NGK	16	2750		https://www.sparkplugs.co.uk/ngk-spark-plug-silzkfr8e7s-90654-5
+NGK Spark plugs	Spark plugs	Xtrail T30, B15, WingRoad Y11	LFR5A-11 (6376)	NGK	16	1850		https://www.sparkplugs.co.uk/ngk-spark-plug-lfr5a-11-6376-5
+NGK Spark plugs	Spark plugs	Xtrail T32	DILKAR7D11H (90565)	NGK	24	4500		https://www.sparkplugs.co.uk/ngk-spark-plug-90565-5
+NGK Spark plugs	Spark plugs		ILFR6A (3588)	NGK	4	3000		
+RIDEX glasses holders 	Accessories	All	100207A0002	RIDEX	29	850		https://en.ridex.eu/product/17152690
+RIDEX Keychain	Accessories	All	100202A0003	RIDEX	30	850		https://en.ridex.eu/product/17371417
+Ring Invertor	Accessories	All		RING	6	3500		
+CVT Strainer	Transmission	E12/		4	5000		
+`;
+
+function parseProductData() {
+  const lines = rawProductData
+    .trim()
+    .split("\n")
+    .filter((line) => line.trim());
+  const products = [];
+
+  lines.forEach((line) => {
+    const columns = line.split("\t");
+    if (columns.length >= 8) {
+      const [
+        name,
+        category,
+        carModel,
+        sku,
+        brand,
+        qty,
+        price,
+        description,
+        imageLink,
+      ] = columns;
+
+      // Clean and normalize SKU for matching
+      const cleanSku = sku.trim().replace(/\s+/g, "");
+
+      products.push({
+        name: name.trim(),
+        category: category.trim(),
+        carModel: carModel.trim(),
+        sku: cleanSku,
+        brand: brand.trim(),
+        stockLevel: parseInt(qty) || 0,
+        inStock: parseInt(qty) > 0,
+        price: parseInt(price.replace(/,/g, "")) || 0,
+        description: description.trim(),
+        imageLink:
+          imageLink && imageLink.trim() !== "" ? imageLink.trim() : null,
+      });
+    }
+  });
+
+  return products;
+}
+
+function generateImageMap() {
+  const parsedProducts = parseProductData();
+  const imageMap = {};
+
+  parsedProducts.forEach((product) => {
+    if (product.imageLink && product.sku) {
+      imageMap[product.sku] = {
+        image: product.imageLink,
+        stockLevel: product.stockLevel,
+        inStock: product.inStock,
+        price: product.price,
+      };
+    }
+  });
+
+  console.log(
+    "Generated image mappings for",
+    Object.keys(imageMap).length,
+    "products",
+  );
+  console.log("\nSample mappings:");
+  console.log(
+    JSON.stringify(
+      Object.fromEntries(Object.entries(imageMap).slice(0, 3)),
+      null,
+      2,
+    ),
+  );
+
+  return imageMap;
+}
+
+function generateUpdateCode() {
+  const imageMap = generateImageMap();
+
+  console.log("\n// Copy this object to use in your products.ts update:");
+  console.log("const updatedProductData = {");
+
+  Object.entries(imageMap).forEach(([sku, data]) => {
+    console.log(`  "${sku}": {`);
+    console.log(`    image: "${data.image}",`);
+    console.log(`    stockLevel: ${data.stockLevel},`);
+    console.log(`    inStock: ${data.inStock},`);
+    console.log(`    price: ${data.price},`);
+    console.log(`  },`);
+  });
+
+  console.log("};");
+
+  console.log("\n// Use this to update your products:");
+  console.log("// const updatedProducts = allProducts.map(product => ({");
+  console.log("//   ...product,");
+  console.log("//   ...(updatedProductData[product.sku] || {})");
+  console.log("// }));");
+
+  return imageMap;
+}
+
+if (require.main === module) {
+  generateUpdateCode();
+}
+
+module.exports = { parseProductData, generateImageMap, generateUpdateCode };

--- a/scripts/upload-images.js
+++ b/scripts/upload-images.js
@@ -1,0 +1,92 @@
+const fs = require("fs");
+const path = require("path");
+
+// Configuration
+const IMAGE_FOLDER = "./product-images"; // Place your images here
+const OUTPUT_FILE = "./app/data/image-urls.json";
+
+// Expected folder structure:
+// product-images/
+//   ├── SKU1/
+//   │   ├── main.jpg
+//   │   ├── alt1.jpg
+//   │   └── alt2.jpg
+//   ├── SKU2/
+//   │   ├── main.jpg
+//   │   └── alt1.jpg
+
+function generateImageMappings() {
+  const imageData = {};
+
+  if (!fs.existsSync(IMAGE_FOLDER)) {
+    console.error(`Folder ${IMAGE_FOLDER} does not exist`);
+    return;
+  }
+
+  const skuFolders = fs.readdirSync(IMAGE_FOLDER);
+
+  skuFolders.forEach((sku) => {
+    const skuPath = path.join(IMAGE_FOLDER, sku);
+
+    if (fs.statSync(skuPath).isDirectory()) {
+      const images = fs
+        .readdirSync(skuPath)
+        .filter((file) => /\.(jpg|jpeg|png|webp)$/i.test(file))
+        .sort();
+
+      if (images.length > 0) {
+        const mainImage =
+          images.find((img) => img.startsWith("main.")) || images[0];
+        const additionalImages = images.filter((img) => img !== mainImage);
+
+        imageData[sku] = {
+          main: `/images/products/${sku}/${mainImage}`,
+          additional: additionalImages.map(
+            (img) => `/images/products/${sku}/${img}`,
+          ),
+        };
+      }
+    }
+  });
+
+  // Save mapping file
+  fs.writeFileSync(OUTPUT_FILE, JSON.stringify(imageData, null, 2));
+  console.log(
+    `Generated image mappings for ${Object.keys(imageData).length} products`,
+  );
+  console.log(`Saved to ${OUTPUT_FILE}`);
+
+  return imageData;
+}
+
+// Usage example for updating products.ts
+function generateProductUpdates() {
+  const imageData = JSON.parse(fs.readFileSync(OUTPUT_FILE, "utf8"));
+
+  console.log("\n// Add this to your products.ts to update images:");
+  console.log("const imageUrls = {");
+
+  Object.entries(imageData).forEach(([sku, urls]) => {
+    console.log(`  "${sku}": {`);
+    console.log(`    image: "${urls.main}",`);
+    if (urls.additional.length > 0) {
+      console.log(
+        `    images: [${urls.additional.map((url) => `"${url}"`).join(", ")}],`,
+      );
+    }
+    console.log(`  },`);
+  });
+
+  console.log("};");
+  console.log("\n// Then update each product:");
+  console.log("// ...product, ...imageUrls[product.sku]");
+}
+
+if (require.main === module) {
+  generateImageMappings();
+  if (fs.existsSync(OUTPUT_FILE)) {
+    generateProductUpdates();
+  }
+}
+
+module.exports = { generateImageMappings, generateProductUpdates };


### PR DESCRIPTION
Updates product image URLs from placeholder images and CDN links to external vendor product pages.

Changes made:
- Replaced Builder.io CDN image URLs with vendor-specific product page URLs
- Updated Unsplash placeholder images with actual product links from AutoDoc, Ridex, and Trodo
- Modified image URLs for multiple product brands including RIDEX, STARK, KAVO, JAPKO, TOPRAN, LPR, Brembo, DAYCO, KAMOKA, and JPN
- Added new utility scripts for managing product images and data parsing

The updated URLs now point directly to vendor product pages for better accuracy and reliability.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/a29a4958937e4d10b959f593f8464467/zenith-landing)

👀 [Preview Link](https://a29a4958937e4d10b959f593f8464467-zenith-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a29a4958937e4d10b959f593f8464467</projectId>-->
<!--<branchName>zenith-landing</branchName>-->